### PR TITLE
fix: dbtの時間ウィンドウフィルターをmodified_gmt基準に修正

### DIFF
--- a/dbt/models/staging/stg_pdf_uploads__extracted_texts.sql
+++ b/dbt/models/staging/stg_pdf_uploads__extracted_texts.sql
@@ -30,8 +30,19 @@ WITH generated AS (
                 content_type = 'application/pdf'
                 {% if var('start_datetime', none) is not none and var('end_datetime', none) is not none %}
 
+                    -- Object Table の述語プッシュダウンを活用するため updated でスキャン範囲を絞る
+                    -- modified_gmt（WordPress更新日時）と updated（GCSアップロード時刻）のズレを考慮して +1日のバッファを持たせる
                     AND updated >= TIMESTAMP('{{ var("start_datetime") }}')
-                    AND updated < TIMESTAMP('{{ var("end_datetime") }}')
+                    AND updated < TIMESTAMP_ADD(TIMESTAMP('{{ var("end_datetime") }}'), INTERVAL 1 DAY)
+                    -- updated_at カラムの定義と一致させるため modified_gmt 優先で正確な時間ウィンドウ判定を行う
+                    AND COALESCE(
+                        TIMESTAMP((SELECT value FROM UNNEST(metadata) WHERE name = 'modified_gmt')),
+                        updated
+                    ) >= TIMESTAMP('{{ var("start_datetime") }}')
+                    AND COALESCE(
+                        TIMESTAMP((SELECT value FROM UNNEST(metadata) WHERE name = 'modified_gmt')),
+                        updated
+                    ) < TIMESTAMP('{{ var("end_datetime") }}')
 
                 {% endif %}
                 {% if is_incremental() %}


### PR DESCRIPTION
## Summary

- `stg_pdf_uploads__extracted_texts` のソースクエリが `updated`（GCSアップロード時刻）でフィルターしていたため、crawlerが `modified_gmt`（WordPress更新日時）を基準に選んだPDFがdbtのウィンドウから除外されるバグを修正
- `updated_at` カラム定義（`COALESCE(modified_gmt, updated)`）とフィルター条件を一致させた
- Object Table の述語プッシュダウンを維持するため `updated` による粗フィルター（+1日バッファ）を残しつつ、`COALESCE(modified_gmt, updated)` で正確な時間ウィンドウ判定を行う複合条件に変更

## 再現ケース

- crawler が 2026-04-11 00:00 JST に実行 → `modified_gmt = 09:58 UTC`、`updated = 15:00:28 UTC` のPDFをアップロード
- dbt ウィンドウ: `[09:00, 15:00) UTC`（0:00 JSTスケジュール）
- 旧: `updated < 15:00:00` → 15:00:28 が**除外**
- 新: `modified_gmt = 09:58:20` で判定 → **正常に処理**

## Test plan

- [ ] `dbt compile --select stg_pdf_uploads__extracted_texts` で生成SQLを確認
- [ ] merge後に `dbt run --select stg_pdf_uploads__extracted_texts+ --vars '{"start_datetime": "2026-04-10T09:00:00Z", "end_datetime": "2026-04-10T15:00:00Z"}'` で未処理PDFを手動回収
- [ ] `stg_pdf_uploads__extracted_texts` に `uri = 'gs://school-agent-lofilab-pdf-uploads/web/2026/04/2860_R8 たちばな誌 No.2.pdf'` が登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)