### PR TITLE
fix: チャンク細切れバグ修正

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -288,9 +288,9 @@ dbtモデル（5モデル、20テスト）は定義済みだが、BigQuery上で
 
 「R8-たちばな誌-No.3.pdf」の CHUNK11〜CHUNK111 が1文ずつの細切れになっている。
 
-- [ ] `dbt/models/intermediate/int_extracted_texts__chunked.sql` の `sentence_groups` CTE を修正
+- [x] `dbt/models/intermediate/int_extracted_texts__chunked.sql` の `sentence_groups` CTE を修正
   - `sentence_group_id` を `FLOOR(cumulative_len / 1500)` に変更
-- [ ] `dbt parse && dbt compile` で構文確認
+- [x] `dbt parse && dbt compile` で構文確認
 - [ ] BigQueryで「R8-たちばな誌-No.3.pdf」のチャンク数が20〜40件程度になることを確認
 
 ### 課題2: 4/17発行ファイルが未取り込み - TODO

--- a/dbt/models/intermediate/int_extracted_texts__chunked.sql
+++ b/dbt/models/intermediate/int_extracted_texts__chunked.sql
@@ -169,33 +169,14 @@ final_chunks AS (
 sentence_groups AS (
     SELECT
         *,
-        -- 句点分割されたもの（sub_index > 0 があるブロック）だけ再グルーピング
-        SUM(
-            CASE
-                -- 累積長が1500を超えたら新グループ開始
-                WHEN cumulative_len > 1500 AND prev_cumulative_len <= 1500 THEN 1
-                WHEN cumulative_len > 1500 AND prev_cumulative_len > 1500 THEN 1
-                ELSE 0
-            END
-        ) OVER (
-            PARTITION BY document_id, section_index, block_order
-            ORDER BY sub_index
-        ) AS sentence_group_id
+        FLOOR(cumulative_len / 1500) AS sentence_group_id
     FROM (
         SELECT
             *,
             SUM(LENGTH(chunk_text) + 1) OVER (
                 PARTITION BY document_id, section_index, block_order
                 ORDER BY sub_index
-            ) AS cumulative_len,
-            COALESCE(
-                SUM(LENGTH(chunk_text) + 1) OVER (
-                    PARTITION BY document_id, section_index, block_order
-                    ORDER BY sub_index
-                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-                ),
-                0
-            ) AS prev_cumulative_len
+            ) AS cumulative_len
         FROM final_chunks
         WHERE sub_index > 0 OR (sub_index = 0 AND section_index >= 0)
     )


### PR DESCRIPTION
## Summary

- `int_extracted_texts__chunked.sql` の `sentence_groups` CTE で `sentence_group_id` の計算が誤っており、1500文字超過後の全文に毎回+1されて各文が独立したチャンクになっていた
- `FLOOR(cumulative_len / 1500)` に置き換えることで正しくグルーピングされるよう修正
- 不要になった `prev_cumulative_len` を削除

## 症状

「R8-たちばな誌-No.3.pdf」の CHUNK11〜CHUNK111 が1文ずつの細切れ（約100チャンク）になっていた。

## Test plan

- [x] `dbt parse && dbt compile` 通過確認済み
- [ ] BigQueryで「R8-たちばな誌-No.3.pdf」のチャンク数が20〜40件程度になることを確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)