### PR TITLE
fix: 1投稿に複数PDF添付がある場合の欠落バグ修正

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -293,15 +293,19 @@ dbtモデル（5モデル、20テスト）は定義済みだが、BigQuery上で
 - [ ] `dbt parse && dbt compile` で構文確認
 - [ ] BigQueryで「R8-たちばな誌-No.3.pdf」のチャンク数が20〜40件程度になることを確認
 
-### 課題2: 4/17発行ファイルが未取り込み - TODO
+### 課題2: 4/17発行ファイルが未取り込み - DONE
 > 詳細プラン: `/home/node/.claude/plans/issue-missing-files-0417.md`
 
-id 2866（たちばな誌 No.3）, 2865（5月のお知らせ）, 2861（たんぽぽ通信 04.17）が
+**根本原因**: WordPress post 2861 に3種の異なるPDFが添付されていたが、
+`selectLatestAttachment` が modified_gmt 最新の1件のみ選択し残り2件（5月のお知らせ、たんぽぽ通信）を欠落させていた。
 
-`gs://school-agent-lofilab-pdf-uploads/web/2026/04/` に存在しない。
-- [ ] GCPログ確認（Cloud Scheduler / Cloud Workflow / Cloud Run Job）
-- [ ] 原因特定後、手動バックフィルまたはコード修正
-- [ ] 取り込み確認: `gsutil ls gs://school-agent-lofilab-pdf-uploads/web/2026/04/`
+**修正**: `deduplicateAttachments` を追加（タイトルごとにグループ化し各グループの最新版を選択）
+- [x] GCPログ確認（Cloud Scheduler / Cloud Workflow / Cloud Run Job）
+- [x] 原因特定: `selectLatestAttachment` による1投稿複数文書の欠落
+- [x] `crawler/src/wordpress.ts` に `deduplicateAttachments` を追加
+- [x] `crawler/src/main.ts` を `deduplicateAttachments` に変更
+- [x] `crawler/__tests__/wordpress.test.ts` にテスト追加（26件全通過）
+- [ ] デプロイ後に手動バックフィル実行（start=2026-04-17T09:00:00Z）して取り込み確認
 
 ---
 

--- a/crawler/__tests__/wordpress.test.ts
+++ b/crawler/__tests__/wordpress.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, afterEach } from '@jest/globals'
-import { fetchLetters, fetchAttachments, selectLatestAttachment, buildGcsPath, sanitizeFilename } from '../src/wordpress.js'
+import { fetchLetters, fetchAttachments, selectLatestAttachment, deduplicateAttachments, buildGcsPath, sanitizeFilename } from '../src/wordpress.js'
 import type { LetterPost, MediaFile } from '../src/types.js'
 
 describe('wordpress', () => {
@@ -156,6 +156,128 @@ describe('wordpress', () => {
       // 順序に関わらず最新が返ること
       expect(selectLatestAttachment([older, newer])).toBe(newer)
       expect(selectLatestAttachment([newer, older])).toBe(newer)
+    })
+  })
+
+  describe('deduplicateAttachments', () => {
+    it('should return empty array for empty input', () => {
+      expect(deduplicateAttachments([])).toEqual([])
+    })
+
+    it('should return all attachments when titles are different', () => {
+      // 4/17の実際のケース: 1つのpostに異なる文書が3件添付されている
+      const tanpopo: MediaFile = {
+        id: 2862,
+        date: '2026-04-17T10:21:19',
+        modified: '2026-04-17T10:21:19',
+        modified_gmt: '2026-04-17T10:21:19',
+        title: { rendered: 'R8 たんぽぽ通信 04.17' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/tanpopo.pdf',
+        post: 2861,
+      }
+      const may: MediaFile = {
+        id: 2863,
+        date: '2026-04-17T10:21:20',
+        modified: '2026-04-17T10:21:20',
+        modified_gmt: '2026-04-17T10:21:20',
+        title: { rendered: 'R8 5月のお知らせ' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/may.pdf',
+        post: 2861,
+      }
+      const tachibana: MediaFile = {
+        id: 2864,
+        date: '2026-04-17T10:21:32',
+        modified: '2026-04-17T10:21:32',
+        modified_gmt: '2026-04-17T10:21:32',
+        title: { rendered: 'R8 たちばな誌 No.3' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/tachibana.pdf',
+        post: 2861,
+      }
+
+      const result = deduplicateAttachments([tanpopo, may, tachibana])
+
+      // 異なるタイトルなので全件返ること
+      expect(result).toHaveLength(3)
+      expect(result).toContain(tanpopo)
+      expect(result).toContain(may)
+      expect(result).toContain(tachibana)
+    })
+
+    it('should keep only latest when same title exists (訂正版ケース)', () => {
+      const older: MediaFile = {
+        id: 2807,
+        date: '2026-03-04T09:46:19Z',
+        modified: '2026-03-04T18:46:19',
+        modified_gmt: '2026-03-04T09:46:19',
+        title: { rendered: 'No.89' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/No.89.pdf',
+        post: 2806,
+      }
+      const newer: MediaFile = {
+        id: 2808,
+        date: '2026-03-04T09:55:17Z',
+        modified: '2026-03-04T18:55:17',
+        modified_gmt: '2026-03-04T09:55:17',
+        title: { rendered: 'No.89' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/No.89-1.pdf',
+        post: 2806,
+      }
+
+      const result = deduplicateAttachments([older, newer])
+
+      // 同じタイトルなので最新の1件のみ返ること（順序不問）
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBe(newer)
+
+      const resultReversed = deduplicateAttachments([newer, older])
+      expect(resultReversed).toHaveLength(1)
+      expect(resultReversed[0]).toBe(newer)
+    })
+
+    it('should handle mix of duplicate titles and unique titles', () => {
+      const olderA: MediaFile = {
+        id: 100,
+        date: '2026-03-01T00:00:00',
+        modified: '2026-03-01T00:00:00',
+        modified_gmt: '2026-03-01T00:00:00',
+        title: { rendered: '文書A' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/a.pdf',
+        post: 1,
+      }
+      const newerA: MediaFile = {
+        id: 101,
+        date: '2026-03-01T01:00:00',
+        modified: '2026-03-01T01:00:00',
+        modified_gmt: '2026-03-01T01:00:00',
+        title: { rendered: '文書A' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/a-1.pdf',
+        post: 1,
+      }
+      const uniqueB: MediaFile = {
+        id: 102,
+        date: '2026-03-01T00:30:00',
+        modified: '2026-03-01T00:30:00',
+        modified_gmt: '2026-03-01T00:30:00',
+        title: { rendered: '文書B' },
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/b.pdf',
+        post: 1,
+      }
+
+      const result = deduplicateAttachments([olderA, newerA, uniqueB])
+
+      // 文書A: 最新のnewerAのみ、文書B: そのまま → 計2件
+      expect(result).toHaveLength(2)
+      expect(result).toContain(newerA)
+      expect(result).toContain(uniqueB)
+      expect(result).not.toContain(olderA)
     })
   })
 

--- a/crawler/src/main.ts
+++ b/crawler/src/main.ts
@@ -2,7 +2,7 @@
 
 import { Storage } from '@google-cloud/storage'
 import { loadConfig } from './config.js'
-import { fetchLetters, fetchAttachments, selectLatestAttachment, buildGcsPath } from './wordpress.js'
+import { fetchLetters, fetchAttachments, deduplicateAttachments, buildGcsPath } from './wordpress.js'
 import {
   isAlreadyUploaded,
   downloadPdf,
@@ -28,37 +28,38 @@ const run = async (): Promise<void> => {
       letter.id,
     )
 
-    // 複数添付がある場合は最新（訂正版）のみ処理する
-    // 設計方針: wordpress.ts の selectLatestAttachment 参照
-    const media = selectLatestAttachment(attachments)
-    if (!media) continue
+    // タイトルベースで重複排除（訂正版は最新のみ、異なる文書は全件）
+    // 設計方針: wordpress.ts の deduplicateAttachments 参照
+    const medias = deduplicateAttachments(attachments)
 
-    const gcsPath = buildGcsPath(media)
+    for (const media of medias) {
+      const gcsPath = buildGcsPath(media)
 
-    // 既にアップロード済みならスキップ（冪等性保証）
-    const alreadyUploaded = await isAlreadyUploaded(
-      storage,
-      config.gcsBucketName,
-      gcsPath,
-    )
-    if (alreadyUploaded) {
-      console.log(`スキップ（既存）: ${gcsPath}`)
-      results.push({ mediaId: media.id, gcsPath, skipped: true })
-      continue
+      // 既にアップロード済みならスキップ（冪等性保証）
+      const alreadyUploaded = await isAlreadyUploaded(
+        storage,
+        config.gcsBucketName,
+        gcsPath,
+      )
+      if (alreadyUploaded) {
+        console.log(`スキップ（既存）: ${gcsPath}`)
+        results.push({ mediaId: media.id, gcsPath, skipped: true })
+        continue
+      }
+
+      const pdfBuffer = await downloadPdf(media.source_url, config.wordpressBaseUrl)
+
+      await uploadToGcs(
+        storage,
+        config.gcsBucketName,
+        gcsPath,
+        pdfBuffer,
+        media,
+      )
+
+      console.log(`アップロード完了: ${gcsPath}`)
+      results.push({ mediaId: media.id, gcsPath, skipped: false })
     }
-
-    const pdfBuffer = await downloadPdf(media.source_url, config.wordpressBaseUrl)
-
-    await uploadToGcs(
-      storage,
-      config.gcsBucketName,
-      gcsPath,
-      pdfBuffer,
-      media,
-    )
-
-    console.log(`アップロード完了: ${gcsPath}`)
-    results.push({ mediaId: media.id, gcsPath, skipped: false })
   }
 
   const uploaded = results.filter((r) => !r.skipped).length

--- a/crawler/src/wordpress.ts
+++ b/crawler/src/wordpress.ts
@@ -64,6 +64,26 @@ export const selectLatestAttachment = (attachments: MediaFile[]): MediaFile | un
 }
 
 /**
+ * 複数添付からタイトルベースで重複を排除する純粋関数
+ *
+ * 【設計方針】
+ * - 同じタイトルの添付が複数ある場合（訂正版）: 最新のみ残す
+ * - タイトルが異なる添付が複数ある場合（1投稿に複数文書）: 全件残す
+ *   例: WordPress運用上、1投稿に複数の異なるPDFが添付されることがある
+ */
+export const deduplicateAttachments = (attachments: MediaFile[]): MediaFile[] => {
+  const groups = new Map<string, MediaFile>()
+  for (const attachment of attachments) {
+    const key = sanitizeFilename(attachment.title.rendered)
+    const existing = groups.get(key)
+    if (!existing || new Date(attachment.modified_gmt).getTime() > new Date(existing.modified_gmt).getTime()) {
+      groups.set(key, attachment)
+    }
+  }
+  return Array.from(groups.values())
+}
+
+/**
  * 指定したletter投稿に紐づくPDF添付ファイルを取得する
  */
 export const fetchAttachments = async (


### PR DESCRIPTION
## Summary

- **原因**: WordPress post 2861 に3種の異なるPDF（たんぽぽ通信・5月のお知らせ・たちばな誌No.3）が添付されていたが、`selectLatestAttachment` が `modified_gmt` 最新の1件のみ選択し残り2件を欠落させていた
- **修正**: `deduplicateAttachments` を追加。タイトルごとにグループ化し各グループの最新版を選択することで、異なる文書は全件・訂正版は最新のみに対応
- **テスト**: `deduplicateAttachments` の4ケースを追加（全26テスト通過）

## デプロイ後の手動バックフィル

CI/CD でクローラーイメージがデプロイされた後、以下を実行して2件の未取り込みファイルを補完する:

```bash
gcloud workflows run school-agent-dbt-scheduler \
  --location=asia-northeast1 \
  --data='{"argument": "{\"start_datetime\": \"2026-04-17T09:00:00Z\", \"end_datetime\": \"2026-04-18T00:00:00Z\"}"}'
```

その後 `gsutil ls gs://school-agent-lofilab-pdf-uploads/web/2026/04/` で以下の2ファイルが追加されることを確認:
- `2862_R8 たんぽぽ通信 04.17.pdf`
- `2863_R8 5月のお知らせ.pdf`

## Test plan

- [x] `cd crawler && npm run test` — 26テスト全通過
- [x] `npm run build` — 全ワークスペースビルド通過
- [ ] CI/CDデプロイ後、手動バックフィルで2ファイルの取り込みを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)