### PR TITLE
fix: int_extracted_texts__chunked の多列 IN サブクエリを NOT EXISTS に修正

### DIFF
--- a/dbt/models/intermediate/int_extracted_texts__chunked.sql
+++ b/dbt/models/intermediate/int_extracted_texts__chunked.sql
@@ -15,23 +15,25 @@
 
 WITH source AS (
     SELECT
-        uri,
-        content_type,
-        size,
-        md5_hash,
-        updated_at,
-        document_id,
+        stg.uri,
+        stg.content_type,
+        stg.size,
+        stg.md5_hash,
+        stg.updated_at,
+        stg.document_id,
         -- 改行を正規化（\r\n → \n）
-        REGEXP_REPLACE(extracted_markdown, r'\r\n', '\n') AS extracted_markdown
-    FROM {{ ref('stg_pdf_uploads__extracted_texts') }}
+        REGEXP_REPLACE(stg.extracted_markdown, r'\r\n', '\n') AS extracted_markdown
+    FROM {{ ref('stg_pdf_uploads__extracted_texts') }} AS stg
     {% if is_incremental() %}
     -- 既存チャンクと同じ (uri, md5_hash) の組み合わせは再処理不要
     -- pre_hook で削除された文書（md5_hash 変化）はここに含まれる
-        WHERE (uri, md5_hash) NOT IN (
-            SELECT DISTINCT
-                t.uri,
-                t.md5_hash
+    -- BigQuery は多列 IN サブクエリ非対応のため NOT EXISTS を使用
+        WHERE NOT EXISTS (
+            SELECT 1
             FROM {{ this }} AS t
+            WHERE
+                t.uri = stg.uri
+                AND t.md5_hash = stg.md5_hash
         )
     {% endif %}
 ),


### PR DESCRIPTION
## Summary

- `int_extracted_texts__chunked` の incremental フィルターで BigQuery 非対応の多列 IN サブクエリ `(uri, md5_hash) NOT IN (SELECT uri, md5_hash ...)` を使用していたため、2026-04-25 以降 dbt パイプラインが連続失敗していた
- `NOT EXISTS` コリレートサブクエリに置き換えることで解消
- これにより `web/2026/04/` および `web/2026/05/` 配下の未取り込み7件（2886〜2899）が次回実行時に処理される

## Test plan

- [x] `dbt parse` でコンパイルエラーなし
- [x] `sqlfluff lint` でlintエラーなし
- [x] `npm run test` で全ワークスペース 80 tests passed
- [ ] デプロイ後に Cloud Workflow の実行が SUCCESS になることを確認
- [ ] BigQuery で document_id 2886〜2899 が `dim_documents` / `exp_api__documents` に登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)