### PR TITLE
fix: delete_stale_chunks マクロの多列 IN サブクエリを NOT EXISTS に修正

### DIFF
--- a/dbt/macros/delete_stale_chunks.sql
+++ b/dbt/macros/delete_stale_chunks.sql
@@ -6,8 +6,11 @@
     SELECT DISTINCT s.document_id
     FROM {{ ref('stg_pdf_uploads__extracted_texts') }} AS s
     WHERE s.uri IN (SELECT DISTINCT uri FROM {{ this }})
-    AND (s.uri, s.md5_hash) NOT IN (
-        SELECT DISTINCT uri, md5_hash FROM {{ this }}
+    AND NOT EXISTS (
+        SELECT 1
+        FROM {{ this }} AS t
+        WHERE t.uri = s.uri
+            AND t.md5_hash = s.md5_hash
     )
   )
   {% endif %}


### PR DESCRIPTION
## Summary

- `delete_stale_chunks()` マクロ（`dbt/macros/delete_stale_chunks.sql`）の pre_hook でも `(s.uri, s.md5_hash) NOT IN (SELECT uri, md5_hash ...)` を使用していたため、パイプラインが継続失敗していた
- `NOT EXISTS` に統一することで解消（モデル本体は PR #28 で修正済み）

## Test plan

- [x] `dbt parse` でコンパイルエラーなし
- [ ] デプロイ後に Cloud Workflow の実行が SUCCEEDED になることを確認
- [ ] BigQuery で document_id 2886〜2899 が全レイヤーに登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)