### PR TITLE
fix: int_document_chunks__embedded の多列 IN サブクエリを NOT EXISTS に修正

### DIFF
--- a/dbt/models/intermediate/int_document_chunks__embedded.sql
+++ b/dbt/models/intermediate/int_document_chunks__embedded.sql
@@ -30,11 +30,13 @@ WITH chunks AS (
     FROM {{ ref('int_extracted_texts__chunked') }}
     {% if is_incremental() %}
         -- chunk_id が存在しても md5_hash（文書コンテンツ）が変わっていれば再 embedding
-        WHERE (chunk_id, md5_hash) NOT IN (
-            SELECT
-                t.chunk_id,
-                t.md5_hash
+        -- BigQuery は多列 IN サブクエリ非対応のため NOT EXISTS を使用
+        WHERE NOT EXISTS (
+            SELECT 1
             FROM {{ this }} AS t
+            WHERE
+                t.chunk_id = chunks.chunk_id
+                AND t.md5_hash = chunks.md5_hash
         )
     {% endif %}
 ),


### PR DESCRIPTION
## Summary

- `int_document_chunks__embedded` の incremental フィルターでも `(chunk_id, md5_hash) NOT IN (...)` を使用していたため、チャンク処理後の embedding ステップでパイプラインが失敗していた
- `NOT EXISTS` コリレートサブクエリに統一（PR #28, #29 と同様の修正）

## Test plan

- [x] `dbt parse` でコンパイルエラーなし
- [x] `sqlfluff lint` でlintエラーなし
- [ ] デプロイ後に Cloud Workflow の実行が SUCCEEDED になることを確認
- [ ] BigQuery で document_id 2886〜2899 が `exp_api__documents` に登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)