### PR TITLE
feat: スクロール位置の復元（BrowserRouter → データルーター移行）

### DIFF
--- a/docs/design/07_frontend_design.md
+++ b/docs/design/07_frontend_design.md
@@ -114,52 +114,48 @@ export const api = {
 
 ### 7.6. ルーティング設計
 
+`createBrowserRouter`（データルーター）を使用する。`ScrollRestoration` によるスクロール位置の自動復元が有効になる。
+
 ```typescript
 // src/App.tsx
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { useAuth } from './hooks/useAuth'
-import Login from './pages/Login'
-import Dashboard from './pages/Dashboard'
-import Gallery from './pages/Gallery'
-import Unauthorized from './pages/Unauthorized'
+import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider, Outlet } from 'react-router-dom'
+import { AuthProvider } from '@/hooks/useAuth'
+import Layout from '@/components/layout/Layout'
+import Login from '@/pages/Login'
+import Documents from '@/pages/Documents'
+import DocumentDetail from '@/pages/DocumentDetail'
+import Chat from '@/pages/Chat'
+import Events from '@/pages/Events'
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth()
-
-  if (isLoading) return <div>Loading...</div>
-  if (!isAuthenticated) return <Navigate to="/login" replace />
-
-  return <>{children}</>
-}
-
-export default function App() {
+function Root() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/unauthorized" element={<Unauthorized />} />
-        <Route
-          path="/dashboard"
-          element={
-            <ProtectedRoute>
-              <Dashboard />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/gallery"
-          element={
-            <ProtectedRoute>
-              <Gallery />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <Outlet />
+    </AuthProvider>
   )
 }
+
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route element={<Root />}>
+      <Route path="/login" element={<Login />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<Events />} />
+        <Route path="/documents" element={<Documents />} />
+        <Route path="/documents/:id" element={<DocumentDetail />} />
+        <Route path="/chat" element={<Chat />} />
+        <Route path="/events" element={<Events />} />
+      </Route>
+    </Route>
+  )
+)
+
+export default function App() {
+  return <RouterProvider router={router} />
+}
 ```
+
+`Layout.tsx` に `<ScrollRestoration />` を配置し、ページ遷移前後のスクロール位置を自動管理する。
 
 ### 7.7. ビルドとデプロイ
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom'
+import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider, Outlet } from 'react-router-dom'
 import { AuthProvider } from '@/hooks/useAuth'
 import Layout from '@/components/layout/Layout'
 import Login from '@/pages/Login'
@@ -7,21 +7,29 @@ import DocumentDetail from '@/pages/DocumentDetail'
 import Chat from '@/pages/Chat'
 import Events from '@/pages/Events'
 
-function App() {
+function Root() {
   return (
     <AuthProvider>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route element={<Layout />}>
-          <Route path="/" element={<Events />} />
-          <Route path="/documents" element={<Documents />} />
-          <Route path="/documents/:id" element={<DocumentDetail />} />
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/events" element={<Events />} />
-        </Route>
-      </Routes>
+      <Outlet />
     </AuthProvider>
   )
 }
 
-export default App
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route element={<Root />}>
+      <Route path="/login" element={<Login />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<Events />} />
+        <Route path="/documents" element={<Documents />} />
+        <Route path="/documents/:id" element={<DocumentDetail />} />
+        <Route path="/chat" element={<Chat />} />
+        <Route path="/events" element={<Events />} />
+      </Route>
+    </Route>
+  )
+)
+
+export default function App() {
+  return <RouterProvider router={router} />
+}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Navigate } from 'react-router-dom'
+import { Outlet, Navigate, ScrollRestoration } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
 import Navbar from './Navbar'
 
@@ -19,6 +19,7 @@ export default function Layout() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <ScrollRestoration />
       <Navbar />
       <main className="max-w-7xl mx-auto px-4 py-8">
         <Outlet />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary

- `BrowserRouter`（レガシーAPI）から `createBrowserRouter`（データルーター）に移行
- `Layout.tsx` に `<ScrollRestoration />` を追加し、ページ遷移前後のスクロール位置を自動復元
- 予定一覧・ドキュメント一覧からリンクを開いて「戻る」した際に、スクロール位置が保持されるようになる

## Test plan

- [ ] 予定一覧（`/events`）でスクロールし、ドキュメントリンクを開いて戻る → スクロール位置が復元されること
- [ ] ドキュメント一覧（`/documents`）でも同様に確認
- [ ] 詳細ページ内の「戻る」リンクでも復元されること
- [ ] `npm run test` 全56テスト通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)