### PR TITLE
fix: package-lock.json 再生成（CDエラー修正）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,18 @@
         "typescript-eslint": "^8.60.0"
       }
     },
+    "backend/node_modules/@hono/node-server": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.4.tgz",
+      "integrity": "sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "crawler": {
       "version": "0.1.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"
   },
-  "overrides": {
-    "@hono/node-server": "2.0.4"
-  },
   "devDependencies": {
     "concurrently": "^9.2.1",
     "typescript": "~5.9.3"


### PR DESCRIPTION
## Summary

PR #37 のマージ後に CD が失敗していた問題を修正。

**原因:** `npm overrides` が期待通りに機能せず、`backend/package.json` が `^2.0.0` を要求しているのに lock file に v2 のエントリが存在しなかったため `npm ci` がエラー。

**修正:**
- ルート `package.json` から `overrides` を削除
- `npm install` を再実行して lock file を再生成
  - `node_modules/@hono/node-server@1.19.14`（`@mastra/core` 経由のトランジティブ）
  - `backend/node_modules/@hono/node-server@2.0.4`（backend 直接依存、v2）

## Test plan

- [x] `npm run test` — 全162件通過
- [x] `npm audit` で `@hono/node-server` 脆弱性なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)