### PR TITLE
chore: TypeScriptビルドのメモリ不足対策

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' tsc",
     "start": "node dist/index.js",
     "lint": "eslint .",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --passWithNoTests",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
+    "incremental": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/crawler/package.json
+++ b/crawler/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' tsc",
     "start": "node dist/main.js",
     "dev": "tsx src/main.ts",
     "lint": "eslint .",

--- a/crawler/tsconfig.json
+++ b/crawler/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
+    "incremental": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
-    "build": "tsc -b && vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' tsc -b && NODE_OPTIONS='--max-old-space-size=4096' vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev -w frontend\" \"npm run dev -w backend\"",
-    "build": "npm run build --workspaces --if-present",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"
   },


### PR DESCRIPTION
## Summary

- 各ワークスペースの `build` スクリプトに `NODE_OPTIONS='--max-old-space-size=4096'` を追加し、ヒープ不足によるビルド失敗を解消
- `backend/tsconfig.json` と `crawler/tsconfig.json` に `incremental: true` を追加し、2回目以降の差分ビルドを高速化・省メモリ化
- `.gitignore` には `*.tsbuildinfo` が既に記載済みのため追加不要

## 背景

TypeScript 6.0.3 + Vite 8.0.14 へのアップデート後、Node.js デフォルトヒープ（~1.5GB）ではフルビルドがメモリ不足で完了できない問題が発生。

## Test plan

- [x] `npm run build` がメモリエラーなく完了することを確認（ローカル検証済み）
- [ ] CI の全ジョブが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)