### PR TITLE
fix: PDFパイプライン課題2 — エラー耐性向上とselectLatestAttachment切り替え

### DIFF
--- a/crawler/__tests__/wordpress.test.ts
+++ b/crawler/__tests__/wordpress.test.ts
@@ -52,6 +52,7 @@ describe('wordpress', () => {
       // 1回目のfetch URLにmodified_afterが含まれること
       const firstCallUrl = fetchMock.mock.calls[0][0] as string
       expect(firstCallUrl).toContain('modified_after=')
+      expect(firstCallUrl).toContain(encodeURIComponent('2026-03-01T00:00:00.000Z'))
       expect(firstCallUrl).toContain('per_page=100')
       expect(firstCallUrl).toContain('page=1')
     })

--- a/crawler/src/main.ts
+++ b/crawler/src/main.ts
@@ -2,7 +2,7 @@
 
 import { Storage } from '@google-cloud/storage'
 import { loadConfig } from './config.js'
-import { fetchLetters, fetchAttachments, deduplicateAttachments, buildGcsPath } from './wordpress.js'
+import { fetchLetters, fetchAttachments, selectLatestAttachment, buildGcsPath } from './wordpress.js'
 import {
   isAlreadyUploaded,
   downloadPdf,
@@ -28,45 +28,46 @@ const run = async (): Promise<void> => {
       letter.id,
     )
 
-    // タイトルベースで重複排除（訂正版は最新のみ、異なる文書は全件）
-    // 設計方針: wordpress.ts の deduplicateAttachments 参照
-    const medias = deduplicateAttachments(attachments)
+    // 複数添付がある場合は最新（訂正版）のみ処理する
+    // 設計方針: wordpress.ts の selectLatestAttachment 参照
+    const media = selectLatestAttachment(attachments)
+    if (!media) continue
 
-    for (const media of medias) {
-      const gcsPath = buildGcsPath(media)
+    const gcsPath = buildGcsPath(media)
 
-      // 既にアップロード済みならスキップ（冪等性保証）
-      const alreadyUploaded = await isAlreadyUploaded(
-        storage,
-        config.gcsBucketName,
-        gcsPath,
-      )
-      if (alreadyUploaded) {
-        console.log(`スキップ（既存）: ${gcsPath}`)
-        results.push({ mediaId: media.id, gcsPath, skipped: true })
-        continue
-      }
+    // 既にアップロード済みならスキップ（冪等性保証）
+    const alreadyUploaded = await isAlreadyUploaded(
+      storage,
+      config.gcsBucketName,
+      gcsPath,
+    )
+    if (alreadyUploaded) {
+      console.log(`スキップ（既存）: ${gcsPath}`)
+      results.push({ mediaId: media.id, gcsPath, skipped: true })
+      continue
+    }
 
+    try {
       const pdfBuffer = await downloadPdf(media.source_url, config.wordpressBaseUrl)
-
-      await uploadToGcs(
-        storage,
-        config.gcsBucketName,
-        gcsPath,
-        pdfBuffer,
-        media,
-      )
-
+      await uploadToGcs(storage, config.gcsBucketName, gcsPath, pdfBuffer, media)
       console.log(`アップロード完了: ${gcsPath}`)
       results.push({ mediaId: media.id, gcsPath, skipped: false })
+    } catch (err) {
+      console.error(`アップロード失敗（継続）: ${gcsPath}`, err)
+      results.push({ mediaId: media.id, gcsPath, skipped: false, error: true })
     }
   }
 
-  const uploaded = results.filter((r) => !r.skipped).length
+  const uploaded = results.filter((r) => !r.skipped && !r.error).length
   const skipped = results.filter((r) => r.skipped).length
+  const errors = results.filter((r) => r.error).length
   console.log(
-    `クローラー完了: アップロード=${uploaded} スキップ=${skipped} 合計=${results.length}`,
+    `クローラー完了: アップロード=${uploaded} スキップ=${skipped} エラー=${errors} 合計=${results.length}`,
   )
+  if (errors > 0) {
+    console.error(`${errors}件のアップロードに失敗しました`)
+    process.exit(1)
+  }
 }
 
 run().catch((err) => {

--- a/crawler/src/types.ts
+++ b/crawler/src/types.ts
@@ -30,4 +30,5 @@ export interface UploadResult {
   mediaId: number;
   gcsPath: string;
   skipped: boolean;
+  error?: boolean;
 }

--- a/docs/design/10_slice_plan.md
+++ b/docs/design/10_slice_plan.md
@@ -56,3 +56,34 @@ dbt run → BigQuery → EXPORT DATA → Cloud Storage (JSON)
 
 Cloud Scheduler `0 0,6,12,18 * * *`（JST 0/6/12/18時）。
 処理範囲は `start_datetime`/`end_datetime` 変数（6時間幅）で制御。
+
+---
+
+## バグ修正: PDFパイプライン課題2 — 4/17発行ファイル未取り込み（2026-04-17判明）
+
+### 症状
+
+WordPress ID 2866, 2865, 2861（2026-04-17発行）が
+`gs://school-agent-lofilab-pdf-uploads/web/2026/04/` に存在しない。
+
+### 根本原因の仮説
+
+- **仮説A**: スケジューラーが未実行（タイミング問題）→ 手動バックフィルで解消
+- **仮説B**: Cloud Run Job のデプロイ失敗またはエラー終了
+- **仮説C**: WordPress API の `modified_after` パラメータをJST時刻で比較 → **実測で偽と判明（2026-06-06）、対応不要**
+  - 検証: `modified_after=2026-06-05T08:25:00Z` で id=2956（modified_gmt=08:26:28）が取得できること、`modified_after=2026-06-05T08:28:00Z` では空配列になることを確認。UTC で正しく比較されている。
+
+### 実装済み修正
+
+#### 修正1: エラー耐性向上（`crawler/src/main.ts`）
+
+1ファイルのダウンロード失敗でジョブ全体が停止する問題を修正。
+for ループ内に try/catch を追加し、失敗した場合も残りのファイルを継続処理する。
+ループ完了後にエラー件数があれば `process.exit(1)` で異常終了を記録する。
+
+`crawler/src/types.ts` の `UploadResult` に `error?: boolean` フィールドを追加。
+
+#### 修正2: deduplicateAttachments 廃止（`crawler/src/main.ts`, `crawler/src/wordpress.ts`）
+
+`deduplicateAttachments`（タイトルベース重複排除）を廃止し、`selectLatestAttachment`（最新1件選択）に切り替え。
+同一投稿に複数PDFが存在する場合、`modified_gmt` が最新のものを採用する。


### PR DESCRIPTION
## Summary

- `crawler/src/main.ts`: PDF download/upload を try/catch でラップ。1ファイル失敗でもジョブが継続し、最後に `process.exit(1)` で異常終了を記録
- `crawler/src/main.ts`: `deduplicateAttachments` → `selectLatestAttachment` に切り替え（複数添付は最新1件のみ処理）
- `crawler/src/types.ts`: `UploadResult` に `error?: boolean` を追加
- タイムゾーンバッファ（仮説C）は WordPress `modified_after` が UTC で正しく動作することを実測確認し、実装しないと判断

## 背景

2026-04-17 に WordPress ID 2865/2866 のPDFがGCSに欠落した件の調査から。
エラー耐性の欠如（1ファイル失敗でジョブ全停止）は確実な問題として修正。
タイムゾーン仮説は `modified_after=2026-06-05T08:25:00Z` の実測で偽と判定。

## Test plan

- [ ] `cd crawler && npm test` が全件グリーン
- [ ] CI（lint/test）がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)